### PR TITLE
Fixes H5parm_exporter.py for numpy 1.12.0

### DIFF
--- a/scripts/H5parm_exporter.py
+++ b/scripts/H5parm_exporter.py
@@ -549,9 +549,9 @@ if __name__=='__main__':
                         nfreq = freqs.shape[0]
                         #print val.shape
                         # reshape such that all freq arrays are filled properly
-                        val = np.tile( val, np.append([nfreq], np.ones(len(val.shape)) ) )
+                        val = np.tile( val, np.append([nfreq], np.ones(len(val.shape),dtype=np.int) ) )
                         #print val.shape
-                        weights = np.tile( weights, np.append([nfreq], np.ones(len(weights.shape)) ) )
+                        weights = np.tile( weights, np.append([nfreq], np.ones(len(weights.shape),dtype=np.int) ) )
 
                     flags = np.zeros(shape=weights.shape, dtype=bool)
                     flags[np.where(weights == 0)] = True


### PR DESCRIPTION
Matches the exact changes to the losoto version of H5parm_exporter.py, tested on numpy 1.11.0 and 1.12.0. Related to Issue #3.

Makes sure that the second argument of numpy.tile is, or contains, integers. Floats are no longer valid after depreciation warnings in numpy versions < 1.12.0.